### PR TITLE
Remove dependency for ~/go/bin with Amass and Subfinder

### DIFF
--- a/domained.py
+++ b/domained.py
@@ -197,14 +197,19 @@ def check_gopath(cmd, install_repo):
             )
         )
     else:
-        print(
-            "\n\033[1;31m{} does not appear to be installed, please run `go get -u -v {}`\033[1;37m".format(
+        ans = input(
+            "\n\033[1;31m{} does not appear to be installed, would you like to run `go get -u -v {}`? [y/N]\033[1;37m".format(
                 cmd, install_repo
             )
         )
 
+        if ans.lower() == "y":
+            print("\n\033[1;31mInstalling {}\033[1;37m".format(install_repo))
+            os.system("go get -u -v {}".format(install_repo))
+            return True
 
-def amass():
+
+def amass(rerun=0):
     if which("amass"):
         print("\n\n\033[1;31mRunning Amass \n\033[1;37m")
         amassFileName = "{}_amass.txt".format(output_base)
@@ -215,10 +220,11 @@ def amass():
         time.sleep(1)
     else:
         print("\n\n\033[1;3mAmass is not currently in your $PATH \n\033[1;37m")
-        check_gopath("amass", "github.com/OWASP/Amass/...")
+        if check_gopath("amass", "github.com/OWASP/Amass/...") and rerun != 1:
+            amass(rerun=1)
 
 
-def subfinder():
+def subfinder(rerun=0):
     if which("subfinder"):
         print("\n\n\033[1;31mRunning Subfinder \n\033[1;37m")
         subfinderFileName = "{}_subfinder.txt".format(output_base)
@@ -229,7 +235,8 @@ def subfinder():
         time.sleep(1)
     else:
         print("\n\n\033[1;3mSubfinder is not currently in your $PATH \n\033[1;37m")
-        check_gopath("subfinder", "github.com/subfinder/subfinder")
+        if check_gopath("subfinder", "github.com/subfinder/subfinder") and rerun != 1:
+            subfinder(rerun=1)
 
 
 def eyewitness(filename):

--- a/domained.py
+++ b/domained.py
@@ -26,6 +26,8 @@ import smtplib
 import time
 from signal import signal, alarm, SIGALRM
 from installer import upgradeFiles
+from shutil import which
+
 
 today = datetime.date.today()
 
@@ -185,24 +187,49 @@ def knockpy():
     time.sleep(1)
 
 
+def check_gopath(cmd, install_repo):
+    if os.environ["GOPATH"]:
+        execs = os.listdir(os.path.join(os.environ["GOPATH"], "bin"))
+    if cmd in execs:
+        print(
+            "\n\033[1;31mFound '{}' in your $GOPATH/bin folder please add this to your $PATH\033[1;37m".format(
+                cmd
+            )
+        )
+    else:
+        print(
+            "\n\033[1;31m{} does not appear to be installed, please run `go get -u -v {}`\033[1;37m".format(
+                cmd, install_repo
+            )
+        )
+
+
 def amass():
-    print("\n\n\033[1;31mRunning Amass \n\033[1;37m")
-    amassFileName = "{}_amass.txt".format(output_base)
-    amassCmd = "~/go/bin/amass -d {} -o {}".format(domain, amassFileName)
-    print("\n\033[1;31mRunning Command: \033[1;37m{}".format(amassCmd))
-    os.system(amassCmd)
-    print("\n\033[1;31mAmass Complete\033[1;37m")
-    time.sleep(1)
+    if which("amass"):
+        print("\n\n\033[1;31mRunning Amass \n\033[1;37m")
+        amassFileName = "{}_amass.txt".format(output_base)
+        amassCmd = "amass -d {} -o {}".format(domain, amassFileName)
+        print("\n\033[1;31mRunning Command: \033[1;37m{}".format(amassCmd))
+        os.system(amassCmd)
+        print("\n\033[1;31mAmass Complete\033[1;37m")
+        time.sleep(1)
+    else:
+        print("\n\n\033[1;3mAmass is not currently in your $PATH \n\033[1;37m")
+        check_gopath("amass", "github.com/OWASP/Amass/...")
 
 
 def subfinder():
-    print("\n\n\033[1;31mRunning Subfinder \n\033[1;37m")
-    subfinderFileName = "{}_subfinder.txt".format(output_base)
-    subfinderCmd = "~/go/bin/subfinder -d {} -o {}".format(domain, subfinderFileName)
-    print("\n\033[1;31mRunning Command: \033[1;37m{}".format(subfinderCmd))
-    os.system(subfinderCmd)
-    print("\n\033[1;31msubfinder Complete\033[1;37m")
-    time.sleep(1)
+    if which("subfinder"):
+        print("\n\n\033[1;31mRunning Subfinder \n\033[1;37m")
+        subfinderFileName = "{}_subfinder.txt".format(output_base)
+        subfinderCmd = "subfinder -d {} -o {}".format(domain, subfinderFileName)
+        print("\n\033[1;31mRunning Command: \033[1;37m{}".format(subfinderCmd))
+        os.system(subfinderCmd)
+        print("\n\033[1;31msubfinder Complete\033[1;37m")
+        time.sleep(1)
+    else:
+        print("\n\n\033[1;3mSubfinder is not currently in your $PATH \n\033[1;37m")
+        check_gopath("subfinder", "github.com/subfinder/subfinder")
 
 
 def eyewitness(filename):
@@ -224,7 +251,6 @@ def eyewitness(filename):
     print("\n\033[1;31mRunning Command: \033[1;37m{}".format(EWHTTPScriptIPS))
     os.system(EWHTTPScriptIPS)
     print("\a")
-
 
 
 def writeFiles(name):

--- a/installer.py
+++ b/installer.py
@@ -71,10 +71,10 @@ def upgradeFiles():
     os.system(subbruteUpgrade)
     print("\nSubbrute Installed\n")
 
-    amassUpgrade = "go get -u github.com/OWASP/Amass/..."
+    amassUpgrade = "go get -u -v github.com/OWASP/Amass/..."
     print("\n\033[1;31mInstalling Amass \033[1;37m")
     os.system(amassUpgrade)
-    subfinderUpgrade = "go get -u github.com/subfinder/subfinder"
+    subfinderUpgrade = "go get -u -v github.com/subfinder/subfinder"
     print("\n\033[1;31mInstalling Subfinder \033[1;37m")
     os.system(subfinderUpgrade)
     massdnsUpgrade = "git clone --branch v0.2 --single-branch https://github.com/blechschmidt/massdns ./bin/massdns"


### PR DESCRIPTION
Used `shutil.which` to check if `amass` and `subfinder` are located within the `$PATH`. If they are it will run the corresponding tool. Otherwise, it will check to see if the `$GOPATH` is set and will check if the executables are located there. If they are it will suggest adding `$GOPATH/bin`  to your `$PATH`. Or it will give you the install command. I also added the `-v` flag to `go get` so it will give a little bit of information when installing the Go applications.